### PR TITLE
Add react-native-svg-asset-plugin

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -44,6 +44,13 @@
     "expo": false
   },
   {
+    "githubUrl": "https://github.com/aeirola/react-native-svg-asset-plugin",
+    "ios": true,
+    "android": true,
+    "web": false,
+    "expo": false
+  },
+  {
     "githubUrl":
       "https://github.com/kenmaca/react-native-apple-ads-attribution",
     "ios": true,


### PR DESCRIPTION
Not strictly a react native library since it is a build plugin, but I think it is still useful for some react native developers.