### PR TITLE
fix: bug on react-native-libraries.json

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -2977,6 +2977,7 @@
     "web": false,
     "expo": true
   },
+  {
     "githubUrl": "https://github.com/artyorsh/react-native-eva-icons",
     "ios": true,
     "android": true,


### PR DESCRIPTION
Missing bracket on react-native-libraries.json